### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Visit [Automatic API REST](http://automaticapirest.info/) to view our demo.
 * Twitter: <a href="http://twitter.com/alex_esquiva">@alex_esquiva</a>
 
 
-###License
+### License
 
     Copyright 2014 GeekyTheory (Alejandro Esquiva)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
